### PR TITLE
Add usb otg fs example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 3
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.5",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +68,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal 0.2.5",
+ "bitfield",
+ "cortex-m 0.7.4",
+ "volatile-register",
 ]
 
 [[package]]
@@ -119,6 +153,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,7 +201,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab1f00eac22bd18f8e5cae9555f2820b3a0c166b5b556ee3e203746ea6dcf3a"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.4",
  "rtt-target",
 ]
 
@@ -179,7 +241,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.4",
  "ufmt-write",
 ]
 
@@ -233,7 +295,7 @@ name = "stm32l4"
 version = "0.14.0"
 dependencies = [
  "bare-metal 1.0.0",
- "cortex-m",
+ "cortex-m 0.7.4",
  "cortex-m-rt",
  "vcell",
 ]
@@ -244,7 +306,7 @@ version = "0.6.0"
 dependencies = [
  "bxcan",
  "cast",
- "cortex-m",
+ "cortex-m 0.7.4",
  "embedded-dma",
  "embedded-hal",
  "fugit",
@@ -252,6 +314,7 @@ dependencies = [
  "rand_core",
  "stable_deref_trait",
  "stm32l4",
+ "synopsys-usb-otg",
  "void",
 ]
 
@@ -259,12 +322,14 @@ dependencies = [
 name = "swan-quickstart"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.4",
  "cortex-m-rt",
  "panic-probe",
  "rtt-target",
  "stm32l4",
  "stm32l4xx-hal",
+ "usb-device",
+ "usbd-serial",
 ]
 
 [[package]]
@@ -279,6 +344,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "synopsys-usb-otg"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1216cb0fe29f65bfffe03c364640202eed1291d85d2f62bbadbe670106786e5"
+dependencies = [
+ "cortex-m 0.6.7",
+ "usb-device",
+ "vcell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "ufmt-write"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,10 +373,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "usb-device"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be90410d4772074ea49525e2e753b65920b94b57eee21a6ef7b6a6fe6296245"
+
+[[package]]
+name = "usbd-serial"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+dependencies = [
+ "embedded-hal",
+ "nb 0.1.3",
+ "usb-device",
+]
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,12 @@ edition = "2021"
 cortex-m = "0.7.4"
 cortex-m-rt = "0.7.1"
 panic-probe = { version = "0.3.0", features = [ "print-rtt" ] }
-stm32l4xx-hal = { version = "0.6.0", features = ["stm32l4r5", "rt"] }
+stm32l4xx-hal = { version = "0.6.0", features = ["stm32l4r5", "rt", "otg_fs"] }
 stm32l4 = { version = "0.14", features = [ "stm32l4r5", "rt" ] }
 rtt-target = { version = "0.3.1", features = [ "cortex-m" ] }
+
+usbd-serial = "0.1.1"
+usb-device = "0.2.8"
 
 [patch.crates-io]
 stm32l4 = { path = "../stm32-rs/stm32l4" }

--- a/src/bin/otg_fs.rs
+++ b/src/bin/otg_fs.rs
@@ -1,0 +1,130 @@
+//! OTG USB 2.0 FS serial port example using polling in a busy loop.
+//!
+//! Note: Must build with features "stm32l4x5 otg_fs" or "stm32l4x6 otg_fs".
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::{entry, exception, ExceptionFrame};
+use panic_probe as _;
+use rtt_target::{rprintln, rtt_init_print};
+use stm32l4xx_hal::gpio::Speed;
+use stm32l4xx_hal::otg_fs::{UsbBus, USB};
+use stm32l4xx_hal::prelude::*;
+use stm32l4xx_hal::rcc::{MsiFreq, PllSource};
+use stm32l4xx_hal::stm32::{Peripherals, CRS, PWR, RCC};
+use usb_device::prelude::*;
+
+/// Enable CRS (Clock Recovery System)
+fn enable_crs() {
+    let rcc = unsafe { &(*RCC::ptr()) };
+    rcc.apb1enr1.modify(|_, w| w.crsen().set_bit());
+    let crs = unsafe { &(*CRS::ptr()) };
+    // Initialize clock recovery
+    // Set autotrim enabled.
+    crs.cr.modify(|_, w| w.autotrimen().set_bit());
+    // Enable CR
+    crs.cr.modify(|_, w| w.cen().set_bit());
+}
+
+/// Enables VddUSB power supply
+fn enable_usb_pwr() {
+    // Enable PWR peripheral
+    let rcc = unsafe { &(*RCC::ptr()) };
+    rcc.apb1enr1.modify(|_, w| w.pwren().set_bit());
+
+    // Enable VddUSB
+    let pwr = unsafe { &*PWR::ptr() };
+    pwr.cr2.modify(|_, w| w.usv().set_bit());
+}
+
+static mut EP_MEMORY: [u32; 1024] = [0; 1024];
+
+#[entry]
+unsafe fn main() -> ! {
+    rtt_init_print!();
+    rprintln!("USB Example!");
+
+    let dp = Peripherals::take().unwrap();
+
+    let mut flash = dp.FLASH.constrain();
+    let mut rcc = dp.RCC.constrain();
+    let mut pwr = dp.PWR.constrain(&mut rcc.apb1r1);
+
+    let clocks = rcc
+        .cfgr
+        .msi(MsiFreq::RANGE48M)
+        .pll_source(PllSource::MSI)
+        .hsi48(true)
+        .freeze(&mut flash.acr, &mut pwr);
+
+    // Enable clock recovery system.
+    enable_crs();
+    // Enable USB power (and disable VddUSB power isolation).
+    enable_usb_pwr();
+
+    let mut gpioa = dp.GPIOA.split(&mut rcc.ahb2);
+
+    let usb = USB {
+        usb_global: dp.OTG_FS_GLOBAL,
+        usb_device: dp.OTG_FS_DEVICE,
+        usb_pwrclk: dp.OTG_FS_PWRCLK,
+        hclk: clocks.hclk(),
+        pin_dm: gpioa
+            .pa11
+            .into_alternate(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh)
+            .set_speed(Speed::VeryHigh),
+        pin_dp: gpioa
+            .pa12
+            .into_alternate(&mut gpioa.moder, &mut gpioa.otyper, &mut gpioa.afrh)
+            .set_speed(Speed::VeryHigh),
+    };
+
+    let usb_bus = UsbBus::new(usb, &mut EP_MEMORY);
+
+    let mut usb_serial = usbd_serial::SerialPort::new(&usb_bus);
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake Company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(usbd_serial::USB_CLASS_CDC)
+        .build();
+
+    #[cfg(feature = "semihosting")]
+    hprintln!("Polling!").ok();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut usb_serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match usb_serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match usb_serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[exception]
+unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
+    panic!("{:#?}", ef);
+}


### PR DESCRIPTION
I got the usb working on a NUCLEO-L4R5ZI

also needed to add stm32l4r5 to otg_fs feature list https://github.com/gauteh/stm32l4xx-hal/pull/1

Commented about trying to get usb working here https://github.com/stm32-rs/stm32l4xx-hal/pull/292